### PR TITLE
relationship has to be nullable

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,7 +50,7 @@ model ParentStudentRelationship {
   studentId Int
   parent Parent @relation(fields: [parentId], references: [id], onDelete: Cascade)
   parentId Int
-  relationship String
+  relationship String?
 
   @@id([studentId, parentId])
 }


### PR DESCRIPTION
If a child and parent are linked via the API, the relationship is left as `null`. The only way to update that is through the front-end. Loading the data will then likely fail for many schools, given this is possible. (We are working on fix, but the database schema will still be possible to be null even following that fix.)